### PR TITLE
[ADD] l10n_ar: Be able to validate the cbu number no matter the stdnu…

### DIFF
--- a/addons/l10n_ar/models/res_partner_bank.py
+++ b/addons/l10n_ar/models/res_partner_bank.py
@@ -1,18 +1,32 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, api, _
 from odoo.exceptions import ValidationError
-import stdnum.ar
 import logging
 _logger = logging.getLogger(__name__)
 
 
-def validate_cbu(cbu):
-    try:
-        return stdnum.ar.cbu.validate(cbu)
-    except Exception as error:
-        msg = _("Argentinian CBU was not validated: %s" % repr(error))
-        _logger.log(25, msg)
-        raise ValidationError(msg)
+try:
+    from stdnum.ar.cbu import validate as validate_cbu
+except ImportError:
+    import stdnum
+    _logger.warning("stdnum.ar.cbu is avalaible from stdnum >= 1.6. The one installed is %s" % stdnum.__version__)
+
+    def validate_cbu(number):
+        def _check_digit(number):
+            """Calculate the check digit."""
+            weights = (3, 1, 7, 9)
+            check = sum(int(n) * weights[i % 4] for i, n in enumerate(reversed(number)))
+            return str((10 - check) % 10)
+        number = stdnum.util.clean(number, ' -').strip()
+        if len(number) != 22:
+            raise ValidationError('Invalid Length')
+        if not number.isdigit():
+            raise ValidationError('Invalid Format')
+        if _check_digit(number[:7]) != number[7]:
+            raise ValidationError('Invalid Checksum')
+        if _check_digit(number[8:-1]) != number[-1]:
+            raise ValidationError('Invalid Checksum')
+        return number
 
 
 class ResPartnerBank(models.Model):


### PR DESCRIPTION
…m version

If avaliable will use the stdnum.ar.cbu.validate functionality, if not
we defined our own validate method.

closes odoo/odoo#40632

Signed-off-by: Josse Colpaert <jco@openerp.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
